### PR TITLE
fix issues for random init bugs

### DIFF
--- a/submodules/Propagation/main.h
+++ b/submodules/Propagation/main.h
@@ -40,7 +40,7 @@ struct Camera {
 };
 
 struct Problem {
-    int ref_image_id;
+    int ref_image_id = 0; // init struct, fix bugs for random init bugs
     std::vector<int> src_image_ids;
 };
 


### PR DESCRIPTION
**fix errors for**  if the struct didn't be init befor being used, sometimes it will be random number, so the ref_id 0 is not be passed to struct roblem ref_id correctly.

`[ITER 1] Saving Gaussians [02/03 19:59:31]
Training progress: 3%|█████▋ | 1010/30000 [01:21<34:26, 14.03it/s, Loss=0.3947600]terminate called after throwing an instance of 'cv::Exception'
what(): OpenCV(4.5.4) ./modules/core/src/matrix_expressions.cpp:24: error: (-5:Bad argument) Matrix operand is an empty matrix. in function 'checkOperandsExist'

Aborted (core dumped)
Traceback (most recent call last):
File "train.py", line 372, in
training(lp.extract(args), op.extract(args), pp.extract(args), args.test_iterations, args.save_iterations, args.checkpoint_iterations, args.start_checkpoint, args.debug_from)
File "train.py", line 129, in training
propagated_depth, cost, normal = read_propagted_depth('./cache/propagated_depth')
File "GaussianPro/utils/general_utils.py", line 244, in read_propagted_depth
cost = readDepthDmb(os.path.join(path, 'costs.dmb'))
File "GaussianPro/utils/general_utils.py", line 192, in readDepthDmb
inimage = open(file_path, "rb")
FileNotFoundError: [Errno 2] No such file or directory: './cache/propagated_depth/costs.dmb`

**debug info:**

ref_id, problem_refid : 0, 162345789
Processing image 162345789...
ref id: 162345789 
./cache/propagated_depth
